### PR TITLE
fix(input-class-names-types) Implement fix to input class name types

### DIFF
--- a/types/DayPickerInput.d.ts
+++ b/types/DayPickerInput.d.ts
@@ -1,7 +1,6 @@
 // TypeScript Version: 2.2
 
 import * as React from 'react';
-import { ClassNames } from './common';
 import { DayPickerInputProps } from './props';
 import DayPicker from './DayPicker';
 

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -25,6 +25,12 @@ export interface ClassNames {
   outside: string;
 }
 
+export interface InputClassNames {
+  container: string;
+  overlayWrapper: string;
+  overlay: string;
+}
+
 export interface RangeModifier {
   from: Date;
   to: Date;

--- a/types/props.d.ts
+++ b/types/props.d.ts
@@ -1,7 +1,13 @@
 // TypeScript Version: 2.2
 
 import * as React from 'react';
-import { ClassNames, Modifier, Modifiers, DayModifiers } from './common';
+import {
+  ClassNames,
+  Modifier,
+  Modifiers,
+  DayModifiers,
+  InputClassNames,
+} from './common';
 import { LocaleUtils } from './utils';
 import { DayPickerInput } from './DayPickerInput';
 
@@ -173,7 +179,7 @@ export interface DayPickerInputProps {
   component?: any;
   overlayComponent?: any;
 
-  classNames?: ClassNames;
+  classNames?: InputClassNames;
 
   onDayChange?(
     day: Date,


### PR DESCRIPTION
Implements a fix tha adds missing class names to the day picker input types.
This fix was merge into the main react-day-picker fork in this PR: https://github.com/gpbl/react-day-picker/pull/796

